### PR TITLE
fix(JsBattleConnection.js): Change connection options

### DIFF
--- a/server/JsBattleConnection.js
+++ b/server/JsBattleConnection.js
@@ -22,9 +22,13 @@ var JsBattleConnection = function(mongoConnectionUrl, secondsBetweenRefresh) {
   this.mongoConnectionOptions = {
     server: {
       socketOptions: {
-        keepAlive: 1000
-      },
-      auto_reconnect: true
+        keepAlive: 1
+      }
+    },
+    replset: {
+      socketOptions: {
+        keepAlive: 1
+      }
     }
   };
 


### PR DESCRIPTION
Testing whether having "keepAlive" set for the "replset" property will fix the connection issue...if so, may be able to remove the custom JsBattleConnection class entirely in a future pull request.

Note: Also changing the secondsBetweenRefresh env variable in the current deploy to a very high number while checking this out.
